### PR TITLE
Support for Formatting groups

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.8 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-formattingmodel",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "powerbi-visuals-api": "~5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,10 @@
         "semver": "^7.3.5"
       }
     },
-    "node_modules/powerbi-visuals-api/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -66,16 +66,14 @@
       "integrity": "sha512-ol+h1gF1VRK3n6/wwXR2YMkQsczHU3aiqmqtPl0/KEHPbCBQon/0vcdOVDXFp5QtYj/Ua+LXegD47x8K9FWCzg==",
       "requires": {
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+      }
+    },
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
       }
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-formattingmodel",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "powerbi-visuals-api": "~5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-formattingmodel",
-      "version": "5.0.1",
-      "license": "ISC",
+      "version": "5.0.0",
+      "license": "MIT",
       "dependencies": {
         "powerbi-visuals-api": "~5.1.0"
       }
@@ -31,7 +31,7 @@
         "semver": "^7.3.5"
       }
     },
-    "node_modules/semver": {
+    "node_modules/powerbi-visuals-api/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -66,14 +66,16 @@
       "integrity": "sha512-ol+h1gF1VRK3n6/wwXR2YMkQsczHU3aiqmqtPl0/KEHPbCBQon/0vcdOVDXFp5QtYj/Ua+LXegD47x8K9FWCzg==",
       "requires": {
         "semver": "^7.3.5"
-      }
-    },
-    "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "requires": {
-        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "powerbi-visuals-api": "~5.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/FormattingSettingsComponents.ts
+++ b/src/FormattingSettingsComponents.ts
@@ -43,7 +43,7 @@ export class CardGroupEntity extends NamedEntity {
 }
 
 export class Model {
-    cards: Array<Card>;
+    cards: Array<Cards>;
 }
 
 /** CompositeCard is use to populate a card into the formatting pane with multiple groups */
@@ -83,7 +83,7 @@ export class SimpleCard extends CardGroupEntity {
     onPreProcess?(): void;
 }
 
-export type Card = SimpleCard | CompositeCard;
+export type Cards = SimpleCard | CompositeCard;
 
 export type Slice = SimpleSlice | CompositeSlice;
 

--- a/src/FormattingSettingsComponents.ts
+++ b/src/FormattingSettingsComponents.ts
@@ -383,10 +383,6 @@ export class ImageUpload extends SimpleSlice<powerbi.ImageValue> {
 }
 
 export class ListEditor extends SimpleSlice<visuals.ListEditorValue> {
-    constructor(object: ListEditor) {
-        super(object);
-    }
-
     type?= visuals.FormattingComponent.ListEditor;
 }
 

--- a/src/FormattingSettingsComponents.ts
+++ b/src/FormattingSettingsComponents.ts
@@ -377,12 +377,12 @@ export abstract class CompositeSlice extends NamedEntity implements IFormattingS
         Object.assign(this, object);
     }
 
-    getFormattingSlice?(objectName: string): visuals.CompositeVisualFormattingSlice {
+    getFormattingSlice?(objectName: string, localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.CompositeVisualFormattingSlice {
         const controlType = this.type;
         const propertyName = this.name;
         const componentDisplayName = {
-            displayName: this.displayName,
-            description: this.description,
+            displayName: (localizationManager && this.displayNameKey) ? localizationManager.getDisplayName(this.displayNameKey) : this.displayName,
+            description: (localizationManager && this.descriptionKey) ? localizationManager.getDisplayName(this.descriptionKey) : this.description,
             uid: objectName + '-' + propertyName,
         };
 

--- a/src/FormattingSettingsInterfaces.ts
+++ b/src/FormattingSettingsInterfaces.ts
@@ -1,6 +1,6 @@
 
 import powerbi from "powerbi-visuals-api";
-import { Model } from "./FormattingSettingsComponents";
+import { Model, Slice } from "./FormattingSettingsComponents";
 
 import visuals = powerbi.visuals;
 
@@ -57,4 +57,11 @@ export interface IFormattingSettingsSlice {
      * @param objectName Object name from capabilities
      */
     setPropertiesValues?(dataViewObjects: powerbi.DataViewObjects, objectName: string): void;
+}
+
+export interface IBuildFormattingSlicesParams {
+    slices: Slice[], 
+    objectName: string, 
+    sliceNames: { [name: string]: number; },
+    formattingSlices: visuals.FormattingSlice[]
 }

--- a/src/FormattingSettingsInterfaces.ts
+++ b/src/FormattingSettingsInterfaces.ts
@@ -62,3 +62,7 @@ export interface IFormattingSettingsSlice {
 export interface IFormattingSettingsCard {
     getFormattingCard?(objectName: string, group: visuals.FormattingGroup, localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingCard;
 }
+
+export interface IFormattingSettingsGroup {
+    getFormattingGroup?(objectName: string, localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingGroup;
+}

--- a/src/FormattingSettingsInterfaces.ts
+++ b/src/FormattingSettingsInterfaces.ts
@@ -58,11 +58,3 @@ export interface IFormattingSettingsSlice {
      */
     setPropertiesValues?(dataViewObjects: powerbi.DataViewObjects, objectName: string): void;
 }
-
-export interface IFormattingSettingsCard {
-    getFormattingCard?(objectName: string, group: visuals.FormattingGroup, localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingCard;
-}
-
-export interface IFormattingSettingsGroup {
-    getFormattingGroup?(localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingGroup;
-}

--- a/src/FormattingSettingsInterfaces.ts
+++ b/src/FormattingSettingsInterfaces.ts
@@ -12,7 +12,7 @@ export interface IFormattingSettingsService {
      * @param dataViews metadata dataView object
      * @returns visual formatting settings model 
      */
-    populateFormattingSettingsModel<T extends Model>(typeClass: new () => T, dataViews: powerbi.DataView[]): T;
+    populateFormattingSettingsModel<T extends Model>(typeClass: new () => T, dataView: powerbi.DataView): T;
 
     /**
      * Build formatting model by parsing formatting settings model object 
@@ -64,5 +64,5 @@ export interface IFormattingSettingsCard {
 }
 
 export interface IFormattingSettingsGroup {
-    getFormattingGroup?(objectName: string, localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingGroup;
+    getFormattingGroup?(localizationManager?: powerbi.extensibility.ILocalizationManager): visuals.FormattingGroup;
 }

--- a/src/FormattingSettingsService.ts
+++ b/src/FormattingSettingsService.ts
@@ -59,7 +59,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
             .forEach((card: Card) => {
                 if (!card)
                     return;
-                
+
                 const isSimpleCard = card instanceof SimpleCard;
                 let formattingCard: visuals.FormattingCard = {
                     displayName: (this.localizationManager && card.displayNameKey) ? this.localizationManager.getDisplayName(card.displayNameKey) : card.displayName,
@@ -80,19 +80,8 @@ export class FormattingSettingsService implements IFormattingSettingsService {
                     .forEach((cardGroupInstance: CardGroupEntity, index: number) => {
                         const groupUid = cardGroupInstance.name + "-group";
                         
-                        let formattingGroup: visuals.FormattingGroup;
-
-                        if (isSimpleCard) {
-                            formattingGroup = {
-                                displayName: cardGroupInstance.displayName,
-                                slices: [],
-                                uid: groupUid
-                            };
-                            formattingCard = (<SimpleCard>card).getFormattingCard(objectName, formattingGroup, this.localizationManager);
-                        } else {
-                            formattingGroup = (<Group>cardGroupInstance).getFormattingGroup(this.localizationManager);
-                            formattingCard.groups.push(formattingGroup);
-                        }
+                        const formattingGroup = cardGroupInstance.getFormattingGroup(this.localizationManager);
+                        formattingCard.groups.push(formattingGroup);
                         
                         // In case formatting model adds data points or top categories (Like when you modify specific visual category color).
                         // these categories use same object name and property name from capabilities and the generated uid will be the same for these formatting categories properties
@@ -180,7 +169,9 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         let cardSlicesDefaultDescriptors: visuals.FormattingDescriptor[]
         let cardContainerSlicesDefaultDescriptors: visuals.FormattingDescriptor[] = [];
 
-        const cardGroupInstances = <CardGroupEntity[]>(card instanceof SimpleCard ? [ card ] : card.groups)
+        const cardGroupInstances = <CardGroupEntity[]>(card instanceof SimpleCard ? 
+            [ card ].filter((group: SimpleCard) => group.visible ?? true) : 
+            card.groups.filter((group: Group) => group.visible ?? true));
         cardGroupInstances.forEach((cardGroupInstance: CardGroupEntity) => {
             cardSlicesDefaultDescriptors = this.getSlicesRevertToDefaultDescriptor(card.name, cardGroupInstance.slices, sliceNames);
 

--- a/src/FormattingSettingsService.ts
+++ b/src/FormattingSettingsService.ts
@@ -1,6 +1,6 @@
 import powerbi from "powerbi-visuals-api";
 import { formattingSettings } from ".";
-import { Card, Model, Slice, ToggleSwitch } from "./FormattingSettingsComponents";
+import { Card, Cards, Group, Model, Slice, ToggleSwitch } from "./FormattingSettingsComponents";
 import { IFormattingSettingsService } from "./FormattingSettingsInterfaces";
 
 import visuals = powerbi.visuals;
@@ -25,14 +25,16 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         let dataViewObjects = dataViews?.[0]?.metadata?.objects;
         if (dataViewObjects) {
             // loop over each formatting property and set its new value if exists
-            defaultSettings.cards?.forEach((card: Card) => {
-                card?.slices?.forEach((slice: Slice) => {
-                    slice?.setPropertiesValues(dataViewObjects, card.name);
-                });
-
-                card?.container?.containerItems?.forEach((containerItem: formattingSettings.ContainerItem) => {
-                    containerItem?.slices?.forEach((slice: Slice) => {
+            defaultSettings.cards?.forEach((card: Cards) => {
+                (card instanceof Card ? [ card ] : card.groups).forEach((group: Group) => {
+                    group?.slices?.forEach((slice: Slice) => {
                         slice?.setPropertiesValues(dataViewObjects, card.name);
+                    });
+
+                    group?.container?.containerItems?.forEach((containerItem: formattingSettings.ContainerItem) => {
+                        containerItem?.slices?.forEach((slice: Slice) => {
+                            slice?.setPropertiesValues(dataViewObjects, card.name);
+                        });
                     });
                 });
             });
@@ -50,74 +52,94 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         let formattingModel = {
             cards: []
         }
-
-        formattingSettingsModel.cards?.forEach((card: Card) => {
+        
+        formattingSettingsModel.cards.forEach((card: Cards) => {
             if (!card)
                 return;
+            
+            const isSimpleCard = card instanceof Card;
+            let formattingCard: visuals.FormattingCard = {
+                displayName: card.displayName,
+                groups: [],
+                uid: card.name,
+                analyticsPane: card.analyticsPane,
+            };
 
             const objectName = card.name;
-            const groupUid = card.name + "-group";
 
-            let formattingGroup: visuals.FormattingGroup = {
-                displayName: undefined,
-                slices: [],
-                uid: groupUid
-            }
+            (isSimpleCard ? [ card ] : card.groups).forEach((group: Group) => {
+                const groupUid = group.name + "-group";
 
-            let formattingCard: visuals.FormattingCard = card.getFormattingCard(objectName, formattingGroup, this.localizationManager);
+                let formattingGroup: visuals.FormattingGroup;
 
-            formattingModel.cards.push(formattingCard);
-
-            // In case formatting model adds data points or top categories (Like when you modify specific visual category color).
-            // these categories use same object name and property name from capabilities and the generated uid will be the same for these formatting categories properties
-            // Solution => Save slice names to modify each slice uid to be unique by adding counter value to the new slice uid
-            const sliceNames: { [name: string]: number } = {};
-
-            // Build formatting container slice for each property
-            if (card.container) {
-                const container = card.container;
-                const containerUid = groupUid + "-container";
-                const formattingContainer: visuals.FormattingContainer = {
-                    displayName: (this.localizationManager && container.displayNameKey)
-                        ? this.localizationManager.getDisplayName(container.displayNameKey) : container.displayName,
-                    description: (this.localizationManager && container.descriptionKey)
-                        ? this.localizationManager.getDisplayName(container.descriptionKey) : container.description,
-                    containerItems: [],
-                    uid: containerUid
-                }
-
-                container.containerItems.forEach((containerItem: formattingSettings.ContainerItem) => {
-                    // Build formatting container item object
-                    const containerIemName = containerItem.displayNameKey ? containerItem.displayNameKey : containerItem.displayName;
-                    const containerItemUid: string = containerUid + containerIemName;
-                    let formattingContainerItem: visuals.FormattingContainerItem = {
-                        displayName: (this.localizationManager && containerItem.displayNameKey)
-                            ? this.localizationManager.getDisplayName(containerItem.displayNameKey) : containerItem.displayName,
+                if (isSimpleCard) {
+                    formattingGroup = {
+                        displayName: isSimpleCard ? undefined : group.displayName,
                         slices: [],
-                        uid: containerItemUid
+                        uid: groupUid
+                    };
+                    formattingCard = card.getFormattingCard(objectName, formattingGroup, this.localizationManager);
+                } else {
+                    formattingGroup = group.getFormattingGroup(objectName, this.localizationManager);
+                    formattingCard.groups.push(formattingGroup);
+                }
+                
+                // In case formatting model adds data points or top categories (Like when you modify specific visual category color).
+                // these categories use same object name and property name from capabilities and the generated uid will be the same for these formatting categories properties
+                // Solution => Save slice names to modify each slice uid to be unique by adding counter value to the new slice uid
+                const sliceNames: { [name: string]: number } = {};
+
+                // Build formatting container slice for each property
+                if (group.container) {
+                    const container = group.container;
+                    const containerUid = groupUid + "-container";
+                    const formattingContainer: visuals.FormattingContainer = {
+                        displayName: (this.localizationManager && container.displayNameKey)
+                            ? this.localizationManager.getDisplayName(container.displayNameKey) : container.displayName,
+                        description: (this.localizationManager && container.descriptionKey)
+                            ? this.localizationManager.getDisplayName(container.descriptionKey) : container.description,
+                        containerItems: [],
+                        uid: containerUid
                     }
 
-                    // Build formatting slices and add them to current formatting container item
-                    this.buildFormattingSlices(containerItem.slices, objectName, sliceNames, formattingCard, formattingContainerItem.slices);
-                    formattingContainer.containerItems.push(formattingContainerItem);
-                });
+                    container.containerItems.forEach((containerItem: formattingSettings.ContainerItem) => {
+                        // Build formatting container item object
+                        const containerIemName = containerItem.displayNameKey ? containerItem.displayNameKey : containerItem.displayName;
+                        const containerItemUid: string = containerUid + containerIemName;
+                        let formattingContainerItem: visuals.FormattingContainerItem = {
+                            displayName: (this.localizationManager && containerItem.displayNameKey)
+                                ? this.localizationManager.getDisplayName(containerItem.displayNameKey) : containerItem.displayName,
+                            slices: [],
+                            uid: containerItemUid
+                        }
 
-                formattingGroup.container = formattingContainer;
-            }
+                        // Build formatting slices and add them to current formatting container item
+                        this.buildFormattingSlices(containerItem.slices, objectName, sliceNames, isSimpleCard ? formattingCard : formattingGroup, formattingContainerItem.slices);
+                        formattingContainer.containerItems.push(formattingContainerItem);
+                    });
 
-            if (card.slices) {
-                // Build formatting slice for each property
-                this.buildFormattingSlices(card.slices, objectName, sliceNames, formattingCard, formattingGroup.slices as visuals.FormattingSlice[]);
-            }
+                    formattingGroup.container = formattingContainer;
+                }
+
+                if (group.slices) {
+                    // Build formatting slice for each property
+                    this.buildFormattingSlices(group.slices, objectName, sliceNames, isSimpleCard ? formattingCard : formattingGroup, formattingGroup.slices as visuals.FormattingSlice[]);
+                }
+
+            });
 
             formattingCard.revertToDefaultDescriptors = this.getRevertToDefaultDescriptor(card);
-        });
 
-        return formattingModel;
+            formattingModel.cards.push(formattingCard);
+        });
+console.log(formattingModel);
+    return formattingModel;
     }
 
-    private buildFormattingSlices(slices: formattingSettings.Slice[], objectName: string, sliceNames: { [name: string]: number; }, formattingCard: visuals.FormattingCard, formattingSlices: visuals.FormattingSlice[]) {
-        slices?.forEach((slice: Slice) => {
+    private buildFormattingSlices(slices: formattingSettings.Slice[], objectName: string, sliceNames: { [name: string]: number; }, parent: visuals.FormattingCard | visuals.FormattingGroup, formattingSlices: visuals.FormattingSlice[]) {
+        // Filter slices based on their visibility
+        slices?.filter((slice: Slice) => slice.visible ?? true)
+            .forEach((slice: Slice) => {
             let formattingSlice: visuals.FormattingSlice = slice?.getFormattingSlice(objectName, this.localizationManager);
 
             if (formattingSlice) {
@@ -132,7 +154,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
                 // Set as topLevelToggle if topLevelToggle boolean was set to true
                 if ((slice as ToggleSwitch).topLevelToggle) {
                     formattingSlice.suppressDisplayName = true;
-                    formattingCard.topLevelToggle = <visuals.EnabledSlice>formattingSlice;
+                    parent.topLevelToggle = <visuals.EnabledSlice>formattingSlice;
                 } else {
                     formattingSlices.push(formattingSlice);
                 }
@@ -140,21 +162,25 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         });
     }
 
-    private getRevertToDefaultDescriptor(card: Card): visuals.FormattingDescriptor[] {
+    private getRevertToDefaultDescriptor(card: Cards): visuals.FormattingDescriptor[] {
         // Proceeded slice names are saved to prevent duplicated default descriptors in case of using 
         // formatting categories & selectors, since they have the same descriptor objectName and propertyName
         const sliceNames: { [name: string]: boolean } = {};
         let revertToDefaultDescriptors: visuals.FormattingDescriptor[] = [];
-
-        let cardSlicesDefaultDescriptors: visuals.FormattingDescriptor[] = this.getSlicesRevertToDefaultDescriptor(card.name, card.slices, sliceNames);
-
+        let cardSlicesDefaultDescriptors: visuals.FormattingDescriptor[]
         let cardContainerSlicesDefaultDescriptors: visuals.FormattingDescriptor[] = [];
-        card.container?.containerItems?.forEach((containerItem: formattingSettings.ContainerItem) => {
-            cardContainerSlicesDefaultDescriptors = cardContainerSlicesDefaultDescriptors.concat(
-                this.getSlicesRevertToDefaultDescriptor(card.name, containerItem.slices, sliceNames))
+
+        (card instanceof Card ? [ card ] : card.groups).forEach((group: Group) => {
+            cardSlicesDefaultDescriptors = this.getSlicesRevertToDefaultDescriptor(card.name, group.slices, sliceNames);
+
+            group.container?.containerItems?.forEach((containerItem: formattingSettings.ContainerItem) => {
+                cardContainerSlicesDefaultDescriptors = cardContainerSlicesDefaultDescriptors.concat(
+                    this.getSlicesRevertToDefaultDescriptor(card.name, containerItem.slices, sliceNames))
+            });
+
+            revertToDefaultDescriptors.push(...cardSlicesDefaultDescriptors.concat(cardContainerSlicesDefaultDescriptors));
         });
 
-        revertToDefaultDescriptors = cardSlicesDefaultDescriptors.concat(cardContainerSlicesDefaultDescriptors);
         return revertToDefaultDescriptors;
     }
 

--- a/src/FormattingSettingsService.ts
+++ b/src/FormattingSettingsService.ts
@@ -132,7 +132,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
 
             formattingModel.cards.push(formattingCard);
         });
-console.log(formattingModel);
+
     return formattingModel;
     }
 

--- a/src/FormattingSettingsService.ts
+++ b/src/FormattingSettingsService.ts
@@ -1,6 +1,6 @@
 import powerbi from "powerbi-visuals-api";
 import { formattingSettings } from ".";
-import { Card, CardGroupEntity, CompositeCard, Group, Model, SimpleCard, Slice } from "./FormattingSettingsComponents";
+import { Cards, CardGroupEntity, CompositeCard, Group, Model, SimpleCard, Slice } from "./FormattingSettingsComponents";
 import { IBuildFormattingSlicesParams, IFormattingSettingsService } from "./FormattingSettingsInterfaces";
 
 import visuals = powerbi.visuals;
@@ -25,7 +25,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         let dataViewObjects = dataView?.metadata?.objects;
         if (dataViewObjects) {
             // loop over each formatting property and set its new value if exists
-            defaultSettings.cards?.forEach((card: Card) => {
+            defaultSettings.cards?.forEach((card: Cards) => {
                 if (card instanceof CompositeCard) card.topLevelSlice?.setPropertiesValues(dataViewObjects, card.name);
 
                 const cardGroupInstances = <CardGroupEntity[]>(card instanceof SimpleCard ? [ card ] : card.groups);
@@ -60,7 +60,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         
         formattingSettingsModel.cards
             .filter(({visible = true}) => visible)
-            .forEach((card: Card) => {
+            .forEach((card: Cards) => {
                 let formattingCard: visuals.FormattingCard = {
                     displayName: (this.localizationManager && card.displayNameKey) ? this.localizationManager.getDisplayName(card.displayNameKey) : card.displayName,
                     description: (this.localizationManager && card.descriptionKey) ? this.localizationManager.getDisplayName(card.descriptionKey) : card.description,
@@ -179,7 +179,7 @@ export class FormattingSettingsService implements IFormattingSettingsService {
         });
     }
 
-    private getRevertToDefaultDescriptor(card: Card): visuals.FormattingDescriptor[] {
+    private getRevertToDefaultDescriptor(card: Cards): visuals.FormattingDescriptor[] {
         // Proceeded slice names are saved to prevent duplicated default descriptors in case of using 
         // formatting categories & selectors, since they have the same descriptor objectName and propertyName
         const sliceNames: { [name: string]: boolean } = {};


### PR DESCRIPTION
As the current version of the `powerbi-visuals-utils-formattingmodel` does not support Formatting groups and to em that is one of the big improvements of the new formatting pane, I extended the current module to include the support for Formatting group.

Changelog
- Added support for creating custom Formatting groups
- Added extra attributes to Card, like missing `topLevelToggle` and `disabled`
- Add extra (optional) `visible` slice attribute for easier show/hide slices in a dynamic way
- Synced license in `package.json` to repo license

Please take the option to review this PR and I am open to discuss anything, like naming, structure etc.

Several points to discuss:

- [ ] class naming, like `Group`
- [ ] use/rename `getFormattingGroup` and `getFormattingCard`
- [ ] change version