### PR TITLE
Update Slice Uids assigning

### DIFF
--- a/src/FormattingSettingsInterfaces.ts
+++ b/src/FormattingSettingsInterfaces.ts
@@ -63,5 +63,6 @@ export interface IBuildFormattingSlicesParams {
     slices: Slice[], 
     objectName: string, 
     sliceNames: { [name: string]: number; },
+    selectorsMap: Record<string, { [selector: string]: boolean }>,
     formattingSlices: visuals.FormattingSlice[]
 }


### PR DESCRIPTION
Creating slices with the same uid at this in the formatting service is right, powerbi Identifies the specific slice according to the selector provided.
If there is a need to give a slice a selector, the correct approach is to give each slice a unique selector according to the data point
in the selector field and not in the altConstantSelector.
This change will keep the uid as is if for the same names there is a different selector.
the change also provide backward compatibility.
