### PR TITLE
ItemFlagSelection issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.3
+* Fix ItemFlagSelection unexpected behavior
+
 ## 6.0.2
 * Update powerbi-visuals-api to 5.9.0
 * Add build.yml and codeql-analysis.yml

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Formatting settings service interface **IFormattingSettingsService** has two mai
      * @param dataViews metadata dataView object
      * @returns visual formatting settings model 
      */
-    populateFormattingSettingsModel<T extends Model>(typeClass: new () => T, dataViews: powerbi.DataView[]): T;
+    populateFormattingSettingsModel<T extends Model>(typeClass: new () => T, dataViews: powerbi.DataView): T;
 
     /**
      * Build formatting model by parsing formatting settings model object 
@@ -302,7 +302,7 @@ The slice name should match property name from *capabilities.json*.
 
  ```typescript
  public update(options: VisualUpdateOptions) {
-     this.formattingSettings = this.formattingSettingsService.populateFormattingSettingsModel(VisualFormattingSettingsModel, options.dataViews);
+     this.formattingSettings = this.formattingSettingsService.populateFormattingSettingsModel(VisualFormattingSettingsModel, options.dataViews[0]);
      // ...
  }
  ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/utils/FormattingSettingsUtils.ts
+++ b/src/utils/FormattingSettingsUtils.ts
@@ -38,7 +38,7 @@ export function getPropertyValue(slice: SimpleSlice, value: any, defaultValue: a
         return { value: (value as Fill)?.solid.color };
     }
 
-    if ((slice as ItemDropdown)?.items) {
+    if ((slice as ItemDropdown)?.items && slice.type !== visuals.FormattingComponent.FlagsSelection) {
         const itemsArray = (slice as ItemDropdown).items;
         return itemsArray.find(item => item.value == value);
     }

--- a/src/utils/FormattingSettingsUtils.ts
+++ b/src/utils/FormattingSettingsUtils.ts
@@ -38,7 +38,7 @@ export function getPropertyValue(slice: SimpleSlice, value: any, defaultValue: a
         return { value: (value as Fill)?.solid.color };
     }
 
-    if ((slice as ItemDropdown)?.items && slice.type !== visuals.FormattingComponent.FlagsSelection) {
+    if (slice?.type === visuals.FormattingComponent.Dropdown) {
         const itemsArray = (slice as ItemDropdown).items;
         return itemsArray.find(item => item.value == value);
     }


### PR DESCRIPTION
The main issue relies on the formatting model utils, the visual gets the update with the correct metadata (the value of the objects), when applying the populateFormattingSettingsModel from the formattingmodel ustils, the utils builds ItemFlagSelection slice with a value of this type {value: string | number, displayName} which I believe is wrong to do so, and should be as the value type of with the AutoFlagSelection, the weird behavior on the formatting pane is due the incorrect value it gets when requesting the formattingModel (via getFormattingModel) which contains the incorrect slice,

So the issue is on the [getPropertyValue](https://github.com/microsoft/powerbi-visuals-utils-formattingmodel/blob/main/src/utils/FormattingSettingsUtils.ts),  
 
![image](https://github.com/user-attachments/assets/cab1a349-208a-47a2-ab27-f444c464e444)


in line 41, the ItemFlagSelection satisfy the if statement (since it indeed has items field) while AutoFlagSelection does not have it, and here the incorrect value is created,.
so a proper fix would be to check also the type of the slice before proceeding
