### PR TITLE
fix: sync package-lock version to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-utils-formattingmodel",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-formattingmodel",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "powerbi-visuals-api": "^5.11.0"


### PR DESCRIPTION
## Why

PR #36 bumped `package.json` to `7.1.0` but `package-lock.json` was left at `7.0.1`. This syncs the lockfile root `version` fields to `7.1.0` so they match.

## Change

- `package-lock.json`: `7.0.1` → `7.1.0` (both root and `packages[""].version`).

No dependency changes; metadata-only.